### PR TITLE
Add notice about the repository deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**[DEPRECATED]** _This repository is no longer used, as in Gutenberg we now use the original version of this package._
+
 # @react-native-clipboard/clipboard
 
 [![Build Status][build-badge]][build]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**[DEPRECATED]** _This repository is no longer used, as in Gutenberg we now use the original version of this package, plus fetching [a prebuilt Android artifact from a maven repo on S3](https://github.com/wordpress-mobile/react-native-libraries-publisher/blob/trunk/README.md)._
+## [DEPRECATED] _This repository is no longer used, as in Gutenberg we now use the original version of this package, plus fetching [a prebuilt Android artifact from a maven repo on S3](https://github.com/wordpress-mobile/react-native-libraries-publisher/blob/trunk/README.md)._
 
 # @react-native-clipboard/clipboard
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**[DEPRECATED]** _This repository is no longer used, as in Gutenberg we now use the original version of this package._
+**[DEPRECATED]** _This repository is no longer used, as in Gutenberg we now use the original version of this package, plus fetching [a prebuilt Android artifact from a maven repo on S3](https://github.com/wordpress-mobile/react-native-libraries-publisher/blob/trunk/README.md)._
 
 # @react-native-clipboard/clipboard
 


### PR DESCRIPTION
This package is no longer used in Gutenberg as we now use the original repository ([reference](https://github.com/WordPress/gutenberg/blob/6b28f0e92be69c71f819cf161dd5c007d32e749d/packages/react-native-editor/package.json#L33)). For this reason, I added a notice about the deprecation, and ideally we should archive it.

From the [GitHub documentation about archiving](https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories), everything on the repo will be read-only but not deleted. So, if in the future we need to restore it, we could easily do it by unarchiving it.

@hypest I don't have permission to archive the repository, could you help me with that? Thanks 🙇 .